### PR TITLE
First attempt on fix when model/models event handers are added

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nxus-data-loader",
-  "version": "3.0.0-0",
+  "version": "3.0.0-1",
   "description": "Data format parsers and loaders for nxus",
   "main": "lib",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -180,16 +180,12 @@ export default class DataLoader {
   _modelImport(model_id, results, opts) {
     let loader = this.app.get('data-loader')
     //stub default handlers on "model" and "models" events
-    if((loader.listenerCount('models.'+model_id) + 
-        loader.listenerCount('models.'+model_id+'.before') +
-        loader.listenerCount('models.'+model_id+'.after')) == 0) {
-      this.app.log.debug("data-loader adding default models." + model_id)
+    if((loader.listenerCount('models.'+model_id)) == 0) {
+      this.app.log.debug("data-loader adding handler models." + model_id)
       this.on('models.'+model_id, (args) => {return args})
     }
-    if((loader.listenerCount('model.'+model_id) + 
-        loader.listenerCount('model.'+model_id+'.before') +
-        loader.listenerCount('model.'+model_id+'.after')) == 0) {
-      this.app.log.debug("data-loader adding default model." + model_id)
+    if((loader.listenerCount('model.'+model_id)) == 0) {
+      this.app.log.debug("data-loader adding handler model." + model_id)
       this.on('model.'+model_id, (args) => {return args})
     }
     if (opts === undefined) opts = _defaultImportOptions

--- a/src/index.js
+++ b/src/index.js
@@ -214,14 +214,13 @@ export default class DataLoader {
               } else {
                 var values = _.pick(r, ...model_attrs)
               }
-
               if (hasIdentity) {
                 var criteria = _.pick(values, ...identityFields)
                 action = this._storeResultsWithModel(model, values, criteria)
               } else {
                 action = this._storeResultsWithModel(model, values)
               }
-              return action.catch((e) => {this.app.log.error("Error imporing "+model_id, e, e.details)})
+              return action
             })
           }
           
@@ -230,7 +229,7 @@ export default class DataLoader {
           } else {
             return importResults()
           }
-        })
+        }).catch((e) => {this.app.log.error("Error imporing "+model_id, e, e.details)})
       })
     })
   }
@@ -244,8 +243,10 @@ export default class DataLoader {
    * @return {[type]}                [description]
    */
   _storeResultsWithModel(model, values, uniqueCriteria) {
-    if (uniqueCriteria) return model.createOrUpdate(uniqueCriteria, values)
-    return model.create(values)
+    if (uniqueCriteria) 
+      return model.createOrUpdate(uniqueCriteria, values)
+    else 
+      return model.create(values)
   }
 
 

--- a/test/index.js
+++ b/test/index.js
@@ -7,24 +7,35 @@
 'use strict';
 import _ from 'underscore'
 
-import Module from '../src/'
+import DataLoaderModule from '../src/'
 import CSVParser from '../src/CSVParser'
 import CSVExporter from '../src/CSVExporter'
 import JSONParser from '../src/JSONParser'
 import JSONExporter from '../src/JSONExporter'
 
-import TestApp from 'nxus-core/lib/test/support/TestApp';
+import TestApp from 'nxus-core/lib/test/support/TestApp'
+
+import Sinon from 'sinon'
 
 describe("Data Loader Module", () => {
   var module, app;
  
+  //handler for model events
+  function testAddOneRowHandler(row) {
+    return _.mapObject(row, (value) => {
+      return value + 1;
+    })
+  }
+
+  var addOneRowHandlerSpy = Sinon.spy(testAddOneRowHandler)
+
   beforeEach(() => {
     app = new TestApp();
-    module = new Module(app);
+    module = new DataLoaderModule(app);
   });
   
   describe("Load", () => {
-    it("should not be null", () => Module.should.not.be.null)
+    it("should not be null", () => DataLoaderModule.should.not.be.null)
 
     it("should be instantiated", () => {
       module.should.not.be.null;
@@ -84,7 +95,8 @@ describe("Data Loader Module", () => {
       })
     })
     it("should emit model events", (done) => {
-      // Can't actually use promise because storage does not return
+      // Can't actually use promise because storage does not return: 
+      // TODO: improve this with mock storage?
       module._modelImport("test_model", [{a:1}], {})
       setTimeout(() => {
         app.get('data-loader').emit.calledWith('models.test_model').should.be.true
@@ -93,6 +105,18 @@ describe("Data Loader Module", () => {
         done()
       }, 100)
     })
+    /*
+      ScottM: failing test  - keeping code here and adding an issue
+     */
+    // it("should call registered model event handlers", (done)  => {
+    //   //register handler
+    //   app.get('data-loader').on('model.test_model', testAddOneRowHandler)
+    //   module._modelImport("test_model", [{a:2},{b:2}], {}) 
+    //   setTimeout(() => {
+    //     addOneRowHandlerSpy.calledWith({a:2}).should.be.true
+    //     done()
+    //   }, 100)
+    // })
   })
 
   describe("JSON", () => {


### PR DESCRIPTION
@mjreich:
With this change, gwli app is processing the "model.datarow" event handler just fine, but the handler I've added to "models.datarow.after" sees an empty incoming array in the argument.

I suspect, by a fairly quick look at nxus-core "emit()", that the issue is that there is no default "models.datarow" handler created now with the changes made here -- it looks like that might be needed in order to create the arguments properly for the "after" event in nxus-core.

So if you can confirm: the fix is to add a "model.<id>" and/or "models,<id>" handler if none exists. We shouldn't have to worry about missing .before/.after handlers (right?).
